### PR TITLE
Fix logrotate

### DIFF
--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -8,6 +8,6 @@
 	sharedscripts
 	create 755 mongodb mongodb
 	postrotate
-		kill -SIGUSR1 `cat /run/mongodb/mongod.pid 2>/dev/null` >/dev/null 2>&1
+		kill -USR1 `cat /run/mongodb/mongod.pid 2>/dev/null` >/dev/null 2>&1
 	endscript
 }


### PR DESCRIPTION
logrotate executes the post rotate command in a shell. sh expects the command to be posix conform.
kill -SIGUSR1 does not work on sh and the error is not visible as it's send to /dev/null.
The consequence is, that logrotate renames the file but the kill of the file handler for mongodb fails.
After that, logrotate remains forever in a state that does not detect changes, as the actual log file remains empty, while the old renamed one still gets filled with the logs.